### PR TITLE
getCache, execute(), getInstance(), allowStale(), fixes, test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ yarn add lru-cache-for-clusters-as-promised
 * `stale: true|false`
   * When `true` expired items are return before they are removed rather than `undefined`
 * `prune: false|crontime string`, defaults to `false`
-  * Use a cron job on the master thread to call `prune()` on your cache at regular intervals specified in "crontime", for example "*/30 * * * * *" would prune the cache every 30 seconds (See [`node-cron` patterns](https://www.npmjs.com/package/cron#available-cron-patterns) for more info). Also works in single threaded environments not using the `cluster` module.
+  * Use a cron job on the master thread to call `prune()` on your cache at regular intervals specified in "crontime", for example "*/30 * * * * *" would prune the cache every 30 seconds (See [`node-cron` patterns](https://www.npmjs.com/package/cron#available-cron-patterns) for more info). Also works in single threaded environments not using the `cluster` module. Passing `false` to an existing namespace will disable any jobs that are scheduled.
+* `parse: function`, defaults to `JSON.parse`
+  * Pass in a custom parser function to use for deserializing data sent to/from the cache. This is set on the `LRUCacheForClustersAsPromised` instance and in theory could be different per worker.
+* `stringify: function`, defaults to `JSON.stringify`
+  * Pass in a custom stringifier function to for creating a serializing data sent to/from the cache.
 
 > ! note that `length` and `dispose` are missing as it is not possible to pass `functions` via IPC messages.
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,10 @@ yarn add lru-cache-for-clusters-as-promised
   * Get or update the `max` value for the cache.
 * `maxAge([maxAge])`
   * Get or update the `maxAge` value for the cache.
-* `stale([true|false])`
-  * Get or update the `stale` value for the cache.
+* `allowStale([true|false])`
+  * Get or update the `allowStale` value for the cache (set via `stale` in options). The `stale()` method is deprecated.
+* `execute(command, [arg1, arg2, ...])`
+  * Execute arbitrary command (`LRUCache` function) on the cache, returns whatever value was returned.
 
 # example usage
 **Master**

--- a/README.md
+++ b/README.md
@@ -50,55 +50,68 @@ yarn add lru-cache-for-clusters-as-promised
 
 # api
 
-* `set(key, value, maxAge)`
+## static functions
+
+* `init(): void`
+  * Should be called when `cluster.isMaster === true` to initialize the caches. 
+* `getInstance(options): Promise<LRUCacheForClustersAsPromised>`
+  * Asynchronously returns an `LRUCacheForClustersAsPromised` instance once the underlying `LRUCache` is guaranteed to exist. Uses the same `options` you would pass to the constructor. When constructed synchronously other methods will ensure the underlying cache is created, but this method can be useful from the worker when you plan to interact with the caches directly. Note that this will slow down the construction time on the worker by a few milliseconds while the cache creation is confirmed.
+* `getAllCaches(): { key : LRUCache }`
+  * Synchronously returns a dictionary of the underlying `LRUCache` caches keyed by namespace. Accessible only when `cluster.isMaster === true`, otherwise throws an exception.
+
+## instance functions
+
+* `getCache(): LRUCache`
+  * Gets the underlying `LRUCache`. Accessible only when `cluster.isMaster === true`, otherwise throws an exception.
+* `set(key, value, maxAge): Promise<void>`
   * Sets a value for a key. Specifying the `maxAge` will cause the value to expire per the `stale` value or when `prune`d.
-* `setObject(key, object, maxAge)`
+* `setObject async (key, object, maxAge): Promise<void>`
   * Sets a cache value where the value is an object. Passes the values through `cache.stringify()`, which defaults to `JSON.stringify()`. Use a custom parser like [`flatted`](https://www.npmjs.com/package/flatted) to cases like circular object references.
-* `mSet({ key1: 1, key2: 2, ...}, maxAge)`
+* `mSet({ key1: 1, key2: 2, ...}, maxAge): Promise<void>`
   * Sets multiple key-value pairs in the cache at one time.
-* `mSetObjects({ key1: { obj: 1 }, key2: { obj: 2 }, ...}, maxAge)`
+* `mSetObjects({ key1: { obj: 1 }, key2: { obj: 2 }, ...}, maxAge): Promise<void>`
   * Sets multiple key-value pairs in the cache at one time, where the value is an object. Passes the values through `cache.stringify()`, see `cache.setObject()`;
-* `get(key)`
+* `get(key): Promise<string | number | null | undefined>`
   * Returns a value for a key.
-* `getObject(key)`
+* `getObject(key): Promise<Object | null | undefined>`
   * Returns an object value for a key. Passes the values through `cache.parse()`, which defaults to `JSON.parse()`. Use a custom parser like [`flatted`](https://www.npmjs.com/package/flatted) to cases like circular object references.
-* `mGet([key1, key2, ...])`
+* `mGet([key1, key2, ...]): Promise<{key:string | number | null | undefined}?>`
   * Returns values for multiple keys, results are in the form of `{ key1: '1', key2: '2' }`.
-* `mGetObjects([key1, key2, ...])`
+* `mGetObjects([key1, key2, ...]): Promise<{key:Object | null | undefined}?>`
   * Returns values as objects for multiple keys, results are in the form of `{ key1: '1', key2: '2' }`. Passes the values through `cache.parse()`, see `cache.getObject()`.
-* `peek(key)`
+* `peek(key): Promise<string | number | null | undefined>`
   * Returns the value for a key without updating its last access time.
-* `del(key)`
+* `del(key): Promise<void>`
   * Removes a value from the cache.
-* `mDel([key1, key2...])`
+* `mDel([key1, key2...]): Promise<void>`
   * Removes multiple keys from the cache..
-* `has(key)`
+* `has(key): Promise<boolean>`
   * Returns true if the key exists in the cache.
-* `incr(key, [amount])`
+* `incr(key, [amount]): Promise<number>`
   * Increments a numeric key value by the `amount`, which defaults to `1`. More atomic in a clustered environment.
-* `decr(key, [amount])`
+* `decr(key, [amount]): Promise<number>`
   * Decrements a numeric key value by the `amount`, which defaults to `1`. More atomic in a clustered environment.
-* `reset()`
+* `reset(): Promise<void>`
   * Removes all values from the cache.
-* `keys()`
+* `keys(): Promise<Array<string>>`
   * Returns an array of all the cache keys.
-* `values()`
+* `values(): Promise<Array<string | number>>`
   * Returns an array of all the cache values.
 * `dump()`
   * Returns a serialized array of the cache contents.
-* `prune()`
+* `prune(): Promise<void>`
   * Manually removes items from the cache rather than on get.
-* `length()`
+* `length(): Promise<number>`
   * Return the number of items in the cache.
-* `itemCount()`
+* `itemCount(): Promise<number>`
   * Return the number of items in the cache - same as `length()`.
-* `max([max])`
+* `max([max]): Promise<number | void>`
   * Get or update the `max` value for the cache.
-* `maxAge([maxAge])`
+* `maxAge([maxAge]): Promise<number | void>`
   * Get or update the `maxAge` value for the cache.
-* `allowStale([true|false])`
+* `allowStale([true|false]): Promise<boolean | void>`
   * Get or update the `allowStale` value for the cache (set via `stale` in options). The `stale()` method is deprecated.
-* `execute(command, [arg1, arg2, ...])`
+* `execute(command, [arg1, arg2, ...]): Promise<any>`
   * Execute arbitrary command (`LRUCache` function) on the cache, returns whatever value was returned.
 
 # example usage

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,9 @@ declare module "lru-cache-for-clusters-as-promised" {
         // Load an instance asynchronously to ensure that the cache has been created on the master.
         static getInstance(): Promise<Cache>
 
+        // Get the underlying LRUCache on the master thread (throws exception on worker)
+        getCache(): LRUCache
+
         // Execute arbitrary command (function) on the cache.
         execute(command: string, ...args: any[]): Promise<any>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,107 +40,107 @@ declare module "lru-cache-for-clusters-as-promised" {
         static getLruCaches(): LRUCaches
 
         // Load an instance asynchronously to ensure that the cache has been created on the master.
-        static getInstance(): Promise<Cache>
+        static async getInstance(): Promise<Cache>
 
         // Get the underlying LRUCache on the master thread (throws exception on worker)
         getCache(): LRUCache
 
         // Execute arbitrary command (function) on the cache.
-        execute(command: string, ...args: any[]): Promise<any>
+        async execute(command: string, ...args: any[]): Promise<any>
 
         // Sets a value for a key. Specifying the maxAge will cause the value to expire per the stale value or when pruned.
-        set(key: string, value: G1 | G2 | G3 | G4, maxAge?: number): Promise<void>
+        async set(key: string, value: G1 | G2 | G3 | G4, maxAge?: number): Promise<void>
 
         // Sets a value for a key. Specifying the maxAge will cause the value to expire per the stale value or when pruned.
-        setObject(key: string, object: Object, maxAge?: number): Promise<void>
+        async setObject(key: string, object: Object, maxAge?: number): Promise<void>
 
         // Sets multiple key-value pairs in the cache at one time.
-        mSet(keys: { [index: string]: string | number }, maxAge?: number): Promise<void>
+        async mSet(keys: { [index: string]: string | number }, maxAge?: number): Promise<void>
 
         // Sets multiple key-value pairs in the cache at one time, where the value is an object.
-        mSetObjects(keys: { [index: string]: G1 | G2 | G3 | G4 }, maxAge?: number): Promise<void>
+        async mSetObjects(keys: { [index: string]: G1 | G2 | G3 | G4 }, maxAge?: number): Promise<void>
 
         // Returns a value for a key.
-        get(key: string): Promise<G1 | G2 | G3 | G4 | string | number>
+        async get(key: string): Promise<G1 | G2 | G3 | G4 | string | number>
 
         // Returns a value for a key.
-        getObject(key: string): Promise<Object>
+        async getObject(key: string): Promise<Object>
 
         // Returns values for multiple keys, results are in the form of { key1: '1', key2: '2' }.
-        mGet(keys: Array<string>): Promise<{ [index: string]: string | number }>
+        async mGet(keys: Array<string>): Promise<{ [index: string]: string | number }>
 
         // Returns values as objects for multiple keys, results are in the form of { key1: '1', key2: '2' }.
-        mGetObjects(keys: Array<string>): Promise<{ [index: string]: G1 | G2 | G3 | G4 | string | number}>
+        async mGetObjects(keys: Array<string>): Promise<{ [index: string]: G1 | G2 | G3 | G4 | string | number}>
 
         // Returns the value for a key without updating its last access time.
-        peek(key: string): Promise< G1 | G2 | G3 | G4 | string | number>
+        async peek(key: string): Promise< G1 | G2 | G3 | G4 | string | number>
 
         // Removes a value from the cache.
-        del(key: string): Promise<void>
+        async del(key: string): Promise<void>
 
         // Removes multiple keys from the cache..
-        mDel(keys: Array<string>): Promise<void>
+        async mDel(keys: Array<string>): Promise<void>
 
         // Returns true if the key exists in the cache.
-        has(key: string): Promise<boolean>
+        async has(key: string): Promise<boolean>
 
         // Increments a numeric key value by the amount, which defaults to 1. More atomic in a clustered environment.
-        incr(key: string, amount?: number): Promise<void>
+        async incr(key: string, amount?: number): Promise<void>
 
         // Decrements a numeric key value by the amount, which defaults to 1. More atomic in a clustered environment.
-        decr(key: string, amount?: number): Promise<void>
+        async decr(key: string, amount?: number): Promise<void>
 
         // Removes all values from the cache.
-        reset(): Promise<void>
+        async reset(): Promise<void>
 
         // Returns an array of all the cache keys.
-        keys(): Promise<Array<string>>
+        async keys(): Promise<Array<string>>
 
         // Returns an array of all the cache values.
-        values(): Promise<Array< G1 | G2 | G3 | G4 | string | number>>
+        async values(): Promise<Array< G1 | G2 | G3 | G4 | string | number>>
 
         // Returns a serialized array of the cache contents.
-        dump(): Promise<Array<string>>
+        async dump(): Promise<Array<string>>
 
         // Manually removes items from the cache rather than on get.
-        prune(): Promise<void>
+        async prune(): Promise<void>
 
         // Return the number of items in the cache.
-        length(): Promise<number>
+        async length(): Promise<number>
 
         // Return the number of items in the cache - same as length().
-        itemCount(): Promise<number>
+        async itemCount(): Promise<number>
 
         // Get or update the max value for the cache.
-        max(): Promise<number>
+        async max(): Promise<number>
 
         // Get or update the maxAge value for the cache.
-        max(max: number): Promise<void>
+        async max(max: number): Promise<void>
 
         // Get or update the maxAge value for the cache.
-        maxAge(): Promise<number>
+        async maxAge(): Promise<number>
 
         // Get or update the maxAge value for the cache.
-        maxAge(maxAge: number): Promise<void>
+        async maxAge(maxAge: number): Promise<void>
 
         /**
          * Get or update the stale value for the cache.
          * @deprecated please use allowStale()
          */
-        stale(): Promise<boolean>
+        async stale(): Promise<boolean>
 
         /**
          * Get or update the stale value for the cache.
          * @param stale 
          * @deprecated please use allowStale(stale)
          */
-        stale(stale: boolean): Promise<void>
+        async stale(stale: boolean): Promise<void>
         
         // Get or update the stale value for the cache.
-        allowStale(): Promise<boolean>
+        async allowStale(): Promise<boolean>
 
         // Get or update the stale value for the cache.
-        allowStale(stale: boolean): Promise<void>
+        async allowStale(stale: boolean): Promise<void>
     }
 
     module Cache {

--- a/lib/master-messages.js
+++ b/lib/master-messages.js
@@ -41,7 +41,7 @@ const handleConstructLruCache = (
     lru = caches[request.namespace] = new LRUCache(...params);
     // start a job to clean the cache
     if (params[0].prune) {
-      lru.job = startPruneCronJob(lru, params[0].prune, request.namespace);
+      startPruneCronJob(lru, params[0].prune, request.namespace);
     }
   }
 

--- a/lib/master-messages.js
+++ b/lib/master-messages.js
@@ -132,7 +132,7 @@ const handleDefaultLruFunction = (caches, request, worker) => {
   }
 };
 
-const messageHandlerFunctions = {
+const messageHandlers = {
   '()': handleConstructLruCache,
   mGet: handleGetMultipleValues,
   mSet: handleSetMultipleValues,
@@ -145,6 +145,7 @@ const messageHandlerFunctions = {
   allowStale: handleGetOrSetConfigValue,
   itemCount: handleGetOrSetConfigValue,
   length: handleGetOrSetConfigValue,
+  default: handleDefaultLruFunction,
 };
 
 /**
@@ -152,10 +153,8 @@ const messageHandlerFunctions = {
  * @param {string} func
  * @returns function
  */
-const getMessageHandler = (func) => {
-  const handler = messageHandlerFunctions[func];
-  return handler ? handler : handleDefaultLruFunction;
-};
+const getMessageHandler = (func) =>
+  messageHandlers[func] || messageHandlers.default;
 
 module.exports = {
   getMessageHandler,

--- a/lib/master-messages.js
+++ b/lib/master-messages.js
@@ -23,7 +23,7 @@ const handleConstructLruCache = (
   caches,
   request,
   worker,
-  { startPruneCronJob }
+  { handlePruneCronJob }
 ) => {
   let created = false;
   let lru;
@@ -39,11 +39,10 @@ const handleConstructLruCache = (
   } else {
     created = true;
     lru = caches[request.namespace] = new LRUCache(...params);
-    // start a job to clean the cache
-    if (params[0].prune) {
-      startPruneCronJob(lru, params[0].prune, request.namespace);
-    }
   }
+
+  // use cronjob on master to prune cache, false to disable if running
+  handlePruneCronJob(lru, options.prune, request.namespace);
 
   return handleConstructLruCacheResponse(request, worker, created, lru);
 };

--- a/lib/master-messages.js
+++ b/lib/master-messages.js
@@ -15,7 +15,6 @@ const sendResponseToWorker = (data, request, worker) => {
   const response = data;
   response.source = config.source;
   response.id = request.id;
-  response.func = request.func;
   messages(`Master sending response to worker ${worker.id}`, response);
   worker.send(response);
 };
@@ -34,11 +33,9 @@ const handleConstructLruCache = (
   if (caches[request.namespace]) {
     lru = caches[request.namespace];
     // update property values as needed
-    ['max', 'maxAge', 'stale'].forEach((prop) => {
-      if (options[prop] && options[prop] !== lru[prop]) {
-        lru[prop] = options[prop];
-      }
-    });
+    if (typeof options.max !== 'undefined') lru.max = options.max;
+    if (typeof options.maxAge !== 'undefined') lru.maxAge = options.maxAge;
+    if (typeof options.stale !== 'undefined') lru.allowStale = options.stale;
   } else {
     created = true;
     lru = caches[request.namespace] = new LRUCache(...params);
@@ -59,14 +56,14 @@ const handleConstructLruCacheResponse = (request, worker, created, lru) =>
         isnew: created,
         max: lru.max,
         maxAge: lru.maxAge,
-        stale: lru.stale,
+        stale: lru.allowStale,
       },
     },
     request,
     worker
   );
 
-const handleGetCacheConfigValue = (caches, request, worker) => {
+const handleGetOrSetConfigValue = (caches, request, worker) => {
   const lru = caches[request.namespace];
   const params = request.arguments;
   if (params[0]) {
@@ -104,26 +101,36 @@ const handleIncrementOrDecrement = (caches, request, worker) => {
 
 const handleGetMultipleValues = (caches, request, worker) =>
   handleMultipleValues(caches, request, worker, 'mGet');
-
 const handleSetMultipleValues = (caches, request, worker) =>
   handleMultipleValues(caches, request, worker, 'mSet');
-
 const handleDeleteMultipleValues = (caches, request, worker) =>
   handleMultipleValues(caches, request, worker, 'mDel');
-
 const handleMultipleValues = (caches, request, worker, func) => {
   const value = utils[func](caches[request.namespace], request.arguments);
   return sendResponseToWorker({ value }, request, worker);
 };
 
 const handleDefaultLruFunction = (caches, request, worker) => {
-  return sendResponseToWorker(
-    {
-      value: caches[request.namespace][request.func](...request.arguments),
-    },
-    request,
-    worker
-  );
+  try {
+    if (typeof caches[request.namespace][request.func] !== 'function') {
+      throw new Error(`LRUCache.${request.func}() is not a valid function`);
+    }
+    return sendResponseToWorker(
+      {
+        value: caches[request.namespace][request.func](...request.arguments),
+      },
+      request,
+      worker
+    );
+  } catch (err) {
+    return sendResponseToWorker(
+      {
+        error: err.message,
+      },
+      request,
+      worker
+    );
+  }
 };
 
 const messageHandlerFunctions = {
@@ -133,11 +140,12 @@ const messageHandlerFunctions = {
   mDel: handleDeleteMultipleValues,
   decr: handleIncrementOrDecrement,
   incr: handleIncrementOrDecrement,
-  max: handleGetCacheConfigValue,
-  maxAge: handleGetCacheConfigValue,
-  stale: handleGetCacheConfigValue,
-  itemCount: handleGetCacheConfigValue,
-  length: handleGetCacheConfigValue,
+  max: handleGetOrSetConfigValue,
+  maxAge: handleGetOrSetConfigValue,
+  stale: handleGetOrSetConfigValue,
+  allowStale: handleGetOrSetConfigValue,
+  itemCount: handleGetOrSetConfigValue,
+  length: handleGetOrSetConfigValue,
 };
 
 /**

--- a/lib/master.js
+++ b/lib/master.js
@@ -84,7 +84,7 @@ function getLruCache(caches, namespace, options) {
   return lru;
 }
 
-const getOrSetConfigValue = ({
+const getOrSetConfigValue = async ({
   caches,
   namespace,
   options,
@@ -92,15 +92,13 @@ const getOrSetConfigValue = ({
   funcArgs: value,
 }) => {
   const lru = getLruCache(caches, namespace, options);
-  return new Promise((resolve) => {
-    if (value[0]) {
-      lru[property] = value[0];
-    }
-    return resolve(lru[property]);
-  });
+  if (value[0]) {
+    lru[property] = value[0];
+  }
+  return lru[property];
 };
 
-const incrementOrDecrement = ({
+const incrementOrDecrement = async ({
   caches,
   namespace,
   options,
@@ -108,37 +106,42 @@ const incrementOrDecrement = ({
   funcArgs,
 }) => {
   const lru = getLruCache(caches, namespace, options);
-  return new Promise((resolve) => {
-    // get the current value default to 0
-    let value = lru.get(funcArgs[0]);
-    // maybe initialize and increment
-    value =
-      (typeof value === 'number' ? value : 0) +
-      (funcArgs[1] || 1) * (func === 'decr' ? -1 : 1);
-    // set the new value
-    lru.set(funcArgs[0], value);
-    // resolve the new value
-    return resolve(value);
-  });
+  // get the current value default to 0
+  let value = lru.get(funcArgs[0]);
+  // maybe initialize and increment
+  value =
+    (typeof value === 'number' ? value : 0) +
+    (funcArgs[1] || 1) * (func === 'decr' ? -1 : 1);
+  // set the new value
+  lru.set(funcArgs[0], value);
+  return value;
 };
 
-const getMultipleValues = (options) => handleMultipleValues('mGet', options);
-const setMultipleValues = (options) => handleMultipleValues('mSet', options);
-const deleteMultipleValues = (options) => handleMultipleValues('mDel', options);
-const handleMultipleValues = (func, { namespace, options, funcArgs }) => {
+const getMultipleValues = async (options) =>
+  handleMultipleValues('mGet', options);
+const setMultipleValues = async (options) =>
+  handleMultipleValues('mSet', options);
+const deleteMultipleValues = async (options) =>
+  handleMultipleValues('mDel', options);
+
+const handleMultipleValues = async (func, { namespace, options, funcArgs }) => {
   const lru = getLruCache(caches, namespace, options);
-  return new Promise((resolve) => {
-    return resolve(utils[func](lru, funcArgs));
-  });
+  return utils[func](lru, funcArgs);
 };
 
-const defaultLruFunction = ({ caches, namespace, options, func, funcArgs }) => {
+const defaultLruFunction = async ({
+  caches,
+  namespace,
+  options,
+  func,
+  funcArgs,
+}) => {
   const lru = getLruCache(caches, namespace, options);
   if (typeof lru[func] !== 'function') {
     throw new Error(`LRUCache.${func}() is not a valid function`);
   }
   // just call the function on the lru-cache
-  return Promise.resolve(lru[func](...funcArgs));
+  return lru[func](...funcArgs);
 };
 
 const promiseHandlerFunctions = {
@@ -168,7 +171,7 @@ module.exports = {
     // create the new LRU cache
     getLruCache(caches, namespace, options);
     // return function to promisify function calls
-    return (...args) => {
+    return async (...args) => {
       // acting on the local lru-cache
       messages(namespace, args);
       // first argument is the function to run

--- a/lib/master.js
+++ b/lib/master.js
@@ -30,7 +30,7 @@ function startPruneCronJob(cache, cronTime, namespace) {
   const job = new CronJob({
     cronTime,
     onTick: () => {
-      debug(`Pruning cache ${namespace}`, JSON.stringify(namespace));
+      debug(`Pruning cache ${namespace}`, namespace);
       cache.prune();
     },
     start: true,

--- a/lib/master.js
+++ b/lib/master.js
@@ -178,17 +178,14 @@ module.exports = {
       const func = args[0];
       // the rest of the args are the function arguments of N length
       const funcArgs = Array.prototype.slice.call(args, 1, args.length);
-      try {
-        return getPromiseHandler(func)({
-          caches,
-          namespace,
-          options,
-          func,
-          funcArgs,
-        });
-      } catch (err) {
-        return Promise.reject(err);
-      }
+      // this returns an async function to handle the function call
+      return getPromiseHandler(func)({
+        caches,
+        namespace,
+        options,
+        func,
+        funcArgs,
+      });
     };
   },
 };

--- a/lib/master.js
+++ b/lib/master.js
@@ -15,29 +15,35 @@ const messages = new Debug(`${config.source}-messages`);
 const caches = {};
 
 /**
- * Starts a cron job to prune stale objects from the cache
+ * Starts/stops a cron job to prune stale objects from the cache
  * @param  {LRUCache} cache     The cache we want to prune
  * @param  {string} cronTime  The cron schedule
  * @param  {string} namespace The namespace for shared caches
  * @return {CronJob}           The cron job which has already been started
  */
-function startPruneCronJob(cache, cronTime, namespace) {
-  if (cache.job) {
-    debug('Stopping cache prune job.', namespace);
-    cache.job.stop();
+function handlePruneCronJob(cache, cronTime, namespace) {
+  if (typeof cronTime !== 'undefined') {
+    if (cache.job) {
+      debug(
+        `${cronTime ? 'Updating' : 'Stopping'} cache prune job.`,
+        namespace
+      );
+      cache.job.stop();
+      delete cache.job;
+    }
+    if (cronTime) {
+      debug('Creating cache prune job.', namespace, cronTime);
+      const job = new CronJob({
+        cronTime,
+        onTick: () => {
+          debug(`Pruning cache ${namespace}`, namespace, cronTime);
+          cache.prune();
+        },
+        start: true,
+      });
+      cache.job = job;
+    }
   }
-  debug('Creating cache prune job.', namespace, cronTime);
-  const job = new CronJob({
-    cronTime,
-    onTick: () => {
-      debug(`Pruning cache ${namespace}`, namespace);
-      cache.prune();
-    },
-    start: true,
-    runOnInit: true,
-  });
-  cache.job = job;
-  cache.job.start();
   return cache.job;
 }
 
@@ -54,7 +60,7 @@ if (cluster.isMaster) {
         request,
         worker,
         {
-          startPruneCronJob,
+          handlePruneCronJob,
         }
       );
     });
@@ -73,9 +79,7 @@ function getLruCache(caches, namespace, options) {
     debug(`Created new LRU cache ${namespace}`);
   }
 
-  if (typeof options.prune !== 'undefined') {
-    startPruneCronJob(lru, options.prune, namespace);
-  }
+  handlePruneCronJob(lru, options.prune, namespace);
 
   return lru;
 }

--- a/lib/master.js
+++ b/lib/master.js
@@ -54,7 +54,7 @@ if (cluster.isMaster) {
     // wait for the worker to send a message
     worker.on('message', (request) => {
       if (request.source !== config.source) return;
-      messages(`Master recieved message from worker ${worker.id}`, request);
+      messages(`Master received message from worker ${worker.id}`, request);
       return masterMessages.getMessageHandler(request.func)(
         caches,
         request,
@@ -70,13 +70,13 @@ if (cluster.isMaster) {
 function getLruCache(caches, namespace, options) {
   let lru = caches[namespace];
   if (caches[namespace]) {
-    debug(`Loaded cache from shared namespace ${namespace}`);
+    debug(`Loaded cache from namespace '{namespace}'`);
     if (typeof options.max !== 'undefined') lru.max = options.max;
     if (typeof options.maxAge !== 'undefined') lru.maxAge = options.maxAge;
     if (typeof options.stale !== 'undefined') lru.allowStale = options.stale;
   } else {
     lru = caches[namespace] = new LRUCache(options);
-    debug(`Created new LRU cache ${namespace}`);
+    debug(`Created new LRUCache for namespace '${namespace}'`);
   }
 
   handlePruneCronJob(lru, options.prune, namespace);

--- a/lib/master.js
+++ b/lib/master.js
@@ -57,33 +57,37 @@ if (cluster.isMaster) {
 }
 
 function getLruCache(caches, cache, options, startPruneCronJob) {
+  let lru = caches[cache.namespace];
   if (caches[cache.namespace]) {
     debug(`Loaded cache from shared namespace ${cache.namespace}`);
-    return caches[cache.namespace];
+    if (typeof options.max !== 'undefined') lru.max = options.max;
+    if (typeof options.maxAge !== 'undefined') lru.maxAge = options.maxAge;
+    if (typeof options.stale !== 'undefined') lru.allowStale = options.stale;
+  } else {
+    lru = new LRUCache(options);
+    caches[cache.namespace] = lru;
+    if (options.prune && startPruneCronJob) {
+      lru.job = startPruneCronJob(lru, options.prune, cache.namespace);
+    }
+    debug(`Created new LRU cache ${cache.namespace}`);
   }
 
-  const lru = new LRUCache(options);
-  caches[cache.namespace] = lru;
-  if (options.prune && startPruneCronJob) {
-    lru.job = startPruneCronJob(lru, options.prune, cache.namespace);
-  }
-  debug(`Created new LRU cache ${cache.namespace}`);
   return lru;
 }
 
-const getCacheConfigValue = ({
+const getOrSetConfigValue = ({
   caches,
   namespace,
   options,
-  func,
-  funcArgs,
+  func: property,
+  funcArgs: value,
 }) => {
   const lru = getLruCache(caches, namespace, options);
   return new Promise((resolve) => {
-    if (funcArgs[0]) {
-      lru[func] = funcArgs[0];
+    if (value[0]) {
+      lru[property] = value[0];
     }
-    return resolve(lru[func]);
+    return resolve(lru[property]);
   });
 };
 
@@ -113,7 +117,6 @@ const incrementOrDecrement = ({
 const getMultipleValues = (options) => handleMultipleValues('mGet', options);
 const setMultipleValues = (options) => handleMultipleValues('mSet', options);
 const deleteMultipleValues = (options) => handleMultipleValues('mDel', options);
-
 const handleMultipleValues = (
   func,
   { namespace, options, funcArgs, startPruneCronJob }
@@ -133,9 +136,11 @@ const defaultLruFunction = ({
   startPruneCronJob,
 }) => {
   const lru = getLruCache(caches, namespace, options, startPruneCronJob);
-  return new Promise((resolve) => {
-    return resolve(lru[func](...funcArgs));
-  });
+  if (typeof lru[func] !== 'function') {
+    throw new Error(`LRUCache.${func}() is not a valid function`);
+  }
+  // just call the function on the lru-cache
+  return Promise.resolve(lru[func](...funcArgs));
 };
 
 const promiseHandlerFunctions = {
@@ -144,11 +149,11 @@ const promiseHandlerFunctions = {
   mDel: deleteMultipleValues,
   decr: incrementOrDecrement,
   incr: incrementOrDecrement,
-  max: getCacheConfigValue,
-  maxAge: getCacheConfigValue,
-  stale: getCacheConfigValue,
-  itemCount: getCacheConfigValue,
-  length: getCacheConfigValue,
+  max: getOrSetConfigValue,
+  maxAge: getOrSetConfigValue,
+  allowStale: getOrSetConfigValue,
+  itemCount: getOrSetConfigValue,
+  length: getOrSetConfigValue,
 };
 
 const getPromiseHandler = (func) => {
@@ -160,6 +165,7 @@ const getPromiseHandler = (func) => {
 // the local lru-cache this is the master thread, or from the
 // lru-cache on the master thread if this is a worker
 module.exports = {
+  caches,
   getPromisified: (namespace, options) => {
     return (...args) => {
       // acting on the local lru-cache
@@ -168,14 +174,18 @@ module.exports = {
       const func = args[0];
       // the rest of the args are the function arguments of N length
       const funcArgs = Array.prototype.slice.call(args, 1, args.length);
-      return getPromiseHandler(func)({
-        caches,
-        namespace,
-        options,
-        func,
-        funcArgs,
-        startPruneCronJob,
-      });
+      try {
+        return getPromiseHandler(func)({
+          caches,
+          namespace,
+          options,
+          func,
+          funcArgs,
+          startPruneCronJob,
+        });
+      } catch (err) {
+        return Promise.reject(err);
+      }
     };
   },
 };

--- a/lib/master.js
+++ b/lib/master.js
@@ -22,18 +22,23 @@ const caches = {};
  * @return {CronJob}           The cron job which has already been started
  */
 function startPruneCronJob(cache, cronTime, namespace) {
-  debug('Creating cache prune job.', cache);
+  if (cache.job) {
+    debug('Stopping cache prune job.', namespace);
+    cache.job.stop();
+  }
+  debug('Creating cache prune job.', namespace, cronTime);
   const job = new CronJob({
     cronTime,
     onTick: () => {
-      debug(`Pruning cache ${namespace}`, cache);
+      debug(`Pruning cache ${namespace}`, JSON.stringify(namespace));
       cache.prune();
     },
     start: true,
     runOnInit: true,
   });
-  job.start();
-  return job;
+  cache.job = job;
+  cache.job.start();
+  return cache.job;
 }
 
 // this code will only run on the master to set up handles for messages from the workers
@@ -56,20 +61,20 @@ if (cluster.isMaster) {
   });
 }
 
-function getLruCache(caches, cache, options, startPruneCronJob) {
-  let lru = caches[cache.namespace];
-  if (caches[cache.namespace]) {
-    debug(`Loaded cache from shared namespace ${cache.namespace}`);
+function getLruCache(caches, namespace, options) {
+  let lru = caches[namespace];
+  if (caches[namespace]) {
+    debug(`Loaded cache from shared namespace ${namespace}`);
     if (typeof options.max !== 'undefined') lru.max = options.max;
     if (typeof options.maxAge !== 'undefined') lru.maxAge = options.maxAge;
     if (typeof options.stale !== 'undefined') lru.allowStale = options.stale;
   } else {
-    lru = new LRUCache(options);
-    caches[cache.namespace] = lru;
-    if (options.prune && startPruneCronJob) {
-      lru.job = startPruneCronJob(lru, options.prune, cache.namespace);
-    }
-    debug(`Created new LRU cache ${cache.namespace}`);
+    lru = caches[namespace] = new LRUCache(options);
+    debug(`Created new LRU cache ${namespace}`);
+  }
+
+  if (typeof options.prune !== 'undefined') {
+    startPruneCronJob(lru, options.prune, namespace);
   }
 
   return lru;
@@ -97,9 +102,8 @@ const incrementOrDecrement = ({
   options,
   func,
   funcArgs,
-  startPruneCronJob,
 }) => {
-  const lru = getLruCache(caches, namespace, options, startPruneCronJob);
+  const lru = getLruCache(caches, namespace, options);
   return new Promise((resolve) => {
     // get the current value default to 0
     let value = lru.get(funcArgs[0]);
@@ -117,25 +121,15 @@ const incrementOrDecrement = ({
 const getMultipleValues = (options) => handleMultipleValues('mGet', options);
 const setMultipleValues = (options) => handleMultipleValues('mSet', options);
 const deleteMultipleValues = (options) => handleMultipleValues('mDel', options);
-const handleMultipleValues = (
-  func,
-  { namespace, options, funcArgs, startPruneCronJob }
-) => {
-  const lru = getLruCache(caches, namespace, options, startPruneCronJob);
+const handleMultipleValues = (func, { namespace, options, funcArgs }) => {
+  const lru = getLruCache(caches, namespace, options);
   return new Promise((resolve) => {
     return resolve(utils[func](lru, funcArgs));
   });
 };
 
-const defaultLruFunction = ({
-  caches,
-  namespace,
-  options,
-  func,
-  funcArgs,
-  startPruneCronJob,
-}) => {
-  const lru = getLruCache(caches, namespace, options, startPruneCronJob);
+const defaultLruFunction = ({ caches, namespace, options, func, funcArgs }) => {
+  const lru = getLruCache(caches, namespace, options);
   if (typeof lru[func] !== 'function') {
     throw new Error(`LRUCache.${func}() is not a valid function`);
   }
@@ -166,7 +160,10 @@ const getPromiseHandler = (func) => {
 // lru-cache on the master thread if this is a worker
 module.exports = {
   caches,
-  getPromisified: (namespace, options) => {
+  getPromisified: ({ namespace }, options) => {
+    // create the new LRU cache
+    getLruCache(caches, namespace, options);
+    // return function to promisify function calls
     return (...args) => {
       // acting on the local lru-cache
       messages(namespace, args);
@@ -181,7 +178,6 @@ module.exports = {
           options,
           func,
           funcArgs,
-          startPruneCronJob,
         });
       } catch (err) {
         return Promise.reject(err);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -45,6 +45,9 @@ const requestToMaster = (cache, func, funcArgs) =>
     callbacks[request.id] = (result) => {
       if (failsafeTimeout) {
         clearTimeout(failsafeTimeout);
+        if (typeof result.error !== 'undefined') {
+          return reject(new Error(result.error));
+        }
         return resolve(result.value);
       }
       return false;
@@ -66,14 +69,19 @@ const getPromisified = (cache, options) => {
     return requestToMaster(cache, func, funcArgs);
   };
 
-  // create a new LRU cache on the master
-  promisified('()', options)
-    .then((lruOptions) => debug('created lru cache on master', lruOptions))
-    .catch(
-      /* istanbul ignore next */ (err) => {
-        debug('failed to create lru cache on master', err, options);
-      }
-    );
+  if (!options.noInit) {
+    // create a new LRU cache on the master
+    promisified('()', options)
+      .then((lruOptions) => {
+        // track that we have created this namespace on the master
+        debug('created lru cache on master', options, lruOptions);
+      })
+      .catch(
+        /* istanbul ignore next */ (err) => {
+          debug('failed to create lru cache on master', err, options);
+        }
+      );
+  }
 
   return promisified;
 };

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -21,7 +21,7 @@ if (cluster.isWorker) {
   });
 }
 
-const requestToMaster = (cache, func, funcArgs) =>
+const requestToMaster = async (cache, func, funcArgs) =>
   new Promise((resolve, reject) => {
     // create the request to the master
     const request = {
@@ -50,6 +50,7 @@ const requestToMaster = (cache, func, funcArgs) =>
         }
         return resolve(result.value);
       }
+      // we have already resolve/rejected in the failsafe
       return false;
     };
     // send the request to the master process
@@ -60,7 +61,7 @@ const getPromisified = (cache, options) => {
   // return a promise that resolves to the result of the method on
   // the local lru-cache this is the master thread, or from the
   // lru-cache on the master thread if this is a worker
-  const promisified = (...args) => {
+  const promisified = async (...args) => {
     // first argument is the function to run
     const func = args[0];
     // the rest of the args are the function arguments of N length

--- a/lru-cache-for-clusters-as-promised.js
+++ b/lru-cache-for-clusters-as-promised.js
@@ -103,13 +103,13 @@ class LRUCacheForClustersAsPromised {
   async mGetObjects(keys) {
     const pairs = await this.promisify('mGet', keys);
     const objs = {};
-    await utils.mapObjects(pairs, objs, this.parse, zlib.gunzipSync);
+    await utils.mapObjects(pairs, objs, this.parse);
     return objs;
   }
 
   async mSetObjects(pairs, maxAge) {
     const objs = {};
-    await utils.mapObjects(pairs, objs, this.stringify, zlib.gzipSync);
+    await utils.mapObjects(pairs, objs, this.stringify);
     return this.promisify('mSet', objs, maxAge);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.699",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.699.tgz",
-      "integrity": "sha512-fjt43CPXdPYwD9ybmKbNeLwZBmCVdLY2J5fGZub7/eMPuiqQznOGNXv/wurnpXIlE7ScHnvG9Zi+H4/i6uMKmw==",
+      "version": "1.3.701",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.701.tgz",
+      "integrity": "sha512-Zd9ofdIMYHYhG1gvnejQDvC/kqSeXQvtXF0yRURGxgwGqDZm9F9Fm3dYFnm5gyuA7xpXfBlzVLN1sz0FjxpKfw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -6067,9 +6067,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.3.tgz",
-      "integrity": "sha512-idv5WZvKVXDqKralOImQgPM9v6WOdLNa0IY3B3doOjw/YxRGT8I+allIJ6kd7Uaj+SF1xZUSU+nPM5aDNBVtnw==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
+      "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -7973,9 +7973,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.699",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.699.tgz",
-      "integrity": "sha512-fjt43CPXdPYwD9ybmKbNeLwZBmCVdLY2J5fGZub7/eMPuiqQznOGNXv/wurnpXIlE7ScHnvG9Zi+H4/i6uMKmw==",
+      "version": "1.3.701",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.701.tgz",
+      "integrity": "sha512-Zd9ofdIMYHYhG1gvnejQDvC/kqSeXQvtXF0yRURGxgwGqDZm9F9Fm3dYFnm5gyuA7xpXfBlzVLN1sz0FjxpKfw==",
       "dev": true
     },
     "emoji-regex": {
@@ -11436,9 +11436,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.3.tgz",
-          "integrity": "sha512-idv5WZvKVXDqKralOImQgPM9v6WOdLNa0IY3B3doOjw/YxRGT8I+allIJ6kd7Uaj+SF1xZUSU+nPM5aDNBVtnw==",
+          "version": "7.2.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
+          "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "uuid": "8.3.2"
       },
       "devDependencies": {
+        "async": "^2.1.5",
         "depcheck": "1.4.0",
         "eslint": "7.22.0",
         "eslint-plugin-mocha": "8.1.0",
@@ -44,20 +45,20 @@
       "dev": true
     },
     "node_modules/@babel/core": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
-      "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.13.tgz",
+      "integrity": "sha512-1xEs9jZAyKIouOoCmpsgk/I26PoKyvzQ2ixdRpRzfbcp1fL+ozw7TUgdDgwonbTovqRaTfRh50IXuw4QrWO0GA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@babel/generator": "^7.13.9",
-        "@babel/helper-compilation-targets": "^7.13.10",
-        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.13.13",
+        "@babel/helper-module-transforms": "^7.13.12",
         "@babel/helpers": "^7.13.10",
-        "@babel/parser": "^7.13.10",
+        "@babel/parser": "^7.13.13",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/traverse": "^7.13.13",
+        "@babel/types": "^7.13.13",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -95,12 +96,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
-      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
+      "integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.13.8",
+        "@babel/compat-data": "^7.13.12",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
         "semver": "^6.3.0"
@@ -246,9 +247,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.12.tgz",
-      "integrity": "sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -269,26 +270,25 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
-      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+      "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.0",
+        "@babel/generator": "^7.13.9",
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/parser": "^7.13.13",
+        "@babel/types": "^7.13.13",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "globals": "^11.1.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
-      "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
+      "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -454,14 +454,14 @@
       "dev": true
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.7.tgz",
-      "integrity": "sha512-JFohgBXoyUc3mdeI2WxlhjQZ5fakfemJkZHX8Gu/nFbEg3+lKVUZmNKWmmnp9aOzJQZKoj77LjmFxiP+P+7lMQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.9.tgz",
+      "integrity": "sha512-bHAPwfVoLhGx8d6KV/OfGf/3gwpymVirgfmSyhgv5YuXDybLa6BwjSLvhNMAyDP+4q4pp0p6g248LuoOy5W6OA==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.12.0",
         "@babel/types": "^7.12.0",
-        "@vue/shared": "3.0.7",
+        "@vue/shared": "3.0.9",
         "estree-walker": "^2.0.1",
         "source-map": "^0.6.1"
       }
@@ -476,27 +476,27 @@
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.7.tgz",
-      "integrity": "sha512-VnIH9EbWQm/Tkcp+8dCaNVsVvhm/vxCrIKWRkXY9215hTqOqQOvejT8IMjd2kc++nIsYMsdQk6H9qqBvoLe/Cw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.9.tgz",
+      "integrity": "sha512-tkq6umPSELaghvOExWfGNwrCRc7FTul3RLykKzBZWhb87sSESq0XxiKELfBOfEbzdhWg6BJ1WXKDeq+al/viEQ==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-core": "3.0.7",
-        "@vue/shared": "3.0.7"
+        "@vue/compiler-core": "3.0.9",
+        "@vue/shared": "3.0.9"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.0.7.tgz",
-      "integrity": "sha512-37/QILpGE+J3V+bP9Slg9e6xGqfk+MmS2Yj8ChR4fS0/qWUU/YoYHE0GPIzjmBdH0JVOOmJqunxowIXmqNiHng==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.0.9.tgz",
+      "integrity": "sha512-meneFRb9xIDgv/gYWCr9xKryvPi0tVffQzLjCkyN4RF1EndqLS71xugUX9wQsS4F1SAP+zlZbcgMFmTSC4OpHw==",
       "dev": true,
       "dependencies": {
-        "@babel/parser": "^7.12.0",
-        "@babel/types": "^7.12.0",
-        "@vue/compiler-core": "3.0.7",
-        "@vue/compiler-dom": "3.0.7",
-        "@vue/compiler-ssr": "3.0.7",
-        "@vue/shared": "3.0.7",
+        "@babel/parser": "^7.13.9",
+        "@babel/types": "^7.13.0",
+        "@vue/compiler-core": "3.0.9",
+        "@vue/compiler-dom": "3.0.9",
+        "@vue/compiler-ssr": "3.0.9",
+        "@vue/shared": "3.0.9",
         "consolidate": "^0.16.0",
         "estree-walker": "^2.0.1",
         "hash-sum": "^2.0.0",
@@ -509,7 +509,7 @@
         "source-map": "^0.6.1"
       },
       "peerDependencies": {
-        "vue": "3.0.7"
+        "vue": "3.0.9"
       }
     },
     "node_modules/@vue/compiler-sfc/node_modules/lru-cache": {
@@ -537,52 +537,52 @@
       "dev": true
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.0.7.tgz",
-      "integrity": "sha512-nHRbHeSpfXwjypettjrA16TjgfDcPEwq3m/zHnGyLC1QqdLtklXmpSM43/CPwwTCRa/qdt0pldJf22MiCEuTSQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.0.9.tgz",
+      "integrity": "sha512-99h5k6Up+s8AzTNH1ljtXE/QlnG8yaGLePwQ4XQaWfk23ESUnmGZWEC+y+ZXznf8pIfJ0uPeD9EVgQzQAyZ2aA==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.0.7",
-        "@vue/shared": "3.0.7"
+        "@vue/compiler-dom": "3.0.9",
+        "@vue/shared": "3.0.9"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.7.tgz",
-      "integrity": "sha512-FotWcNNaKhqpFZrdgsUOZ1enlJ5lhTt01CNTtLSyK7jYFgZBTuw8vKsEutZKDYZ1XKotOfoeO8N3pZQqmM6Etw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.9.tgz",
+      "integrity": "sha512-W1AbGhzphVjY+TL32lQDwLDNvLzZKOcUgaIaLOoALWMtjzN4ExOUJzrR1FC3ynlpMHIEfcUo8GPgfnNmvMGdgQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@vue/shared": "3.0.7"
+        "@vue/shared": "3.0.9"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.7.tgz",
-      "integrity": "sha512-DBAZAwVvdmMXuyd6/9qqj/kYr/GaLTmn1L2/QLxLwP+UfhIboiTSBc/tUUb8MRk7Bb98GzNeAWkkT6AfooS3dQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.9.tgz",
+      "integrity": "sha512-j94xZ/wRZTVhqpoUgmxBTlojnPFu6TTXNw1Vw8oQkW1ZTGD0IwiJe3ycsKd1bpleXEMVt55GzGlCopI33/Gdmg==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@vue/reactivity": "3.0.7",
-        "@vue/shared": "3.0.7"
+        "@vue/reactivity": "3.0.9",
+        "@vue/shared": "3.0.9"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.7.tgz",
-      "integrity": "sha512-Oij4ruOtnpQpCj+/Q3JPzgpTJ1Q7+N67pA53A8KVITEtxfvKL46NN6dhAZ5NGqwX6RWZpYqWQNewITeF0pHr8g==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.9.tgz",
+      "integrity": "sha512-6NCjpwa5hNBFDdokquAgMl2tNEYyQD6kBy9Mh6M2776bxYLXZCqL4/e0UrpBuBiHTrkAlUGODD7PyYGaqH6fyA==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@vue/runtime-core": "3.0.7",
-        "@vue/shared": "3.0.7",
+        "@vue/runtime-core": "3.0.9",
+        "@vue/shared": "3.0.9",
         "csstype": "^2.6.8"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.7.tgz",
-      "integrity": "sha512-dn5FyfSc4ky424jH4FntiHno7Ss5yLkqKNmM/NXwANRnlkmqu74pnGetexDFVG5phMk9/FhwovUZCWGxsotVKg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.9.tgz",
+      "integrity": "sha512-lv20q1O5dybwro+V+vnxHCmSIxi9mvTORSgAbGrANGYK8zF4K1S9TOankIvdkcvfZ88IR95O2pTI2Pb3c3BaNg==",
       "dev": true
     },
     "node_modules/accepts": {
@@ -806,12 +806,12 @@
       }
     },
     "node_modules/async": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-      "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "dependencies": {
-        "lodash": "^4.14.0"
+        "lodash": "^4.17.14"
       }
     },
     "node_modules/asynckit": {
@@ -5474,6 +5474,15 @@
         "sloc": "bin/sloc"
       }
     },
+    "node_modules/sloc/node_modules/async": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+      "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.14.0"
+      }
+    },
     "node_modules/sloc/node_modules/commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
@@ -6371,15 +6380,15 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.7.tgz",
-      "integrity": "sha512-8h4TikD+JabbMK9aRlBO4laG0AtNHRPHynxYgWZ9sq1YUPfzynd9Jeeb27XNyZytC7aCQRX9xe1+TQJuc181Tw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.9.tgz",
+      "integrity": "sha512-MOvqDpvDslMWJo5kyGW1nTsTIPAuSzgVqmlzSQInIEqkHOu16pNbXuTjnG7jc/yIvQYFSQZqv6Pvad0iO5QkyQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.0.7",
-        "@vue/runtime-dom": "3.0.7",
-        "@vue/shared": "3.0.7"
+        "@vue/compiler-dom": "3.0.9",
+        "@vue/runtime-dom": "3.0.9",
+        "@vue/shared": "3.0.9"
       }
     },
     "node_modules/which": {
@@ -6667,20 +6676,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
-      "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.13.tgz",
+      "integrity": "sha512-1xEs9jZAyKIouOoCmpsgk/I26PoKyvzQ2ixdRpRzfbcp1fL+ozw7TUgdDgwonbTovqRaTfRh50IXuw4QrWO0GA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@babel/generator": "^7.13.9",
-        "@babel/helper-compilation-targets": "^7.13.10",
-        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.13.13",
+        "@babel/helper-module-transforms": "^7.13.12",
         "@babel/helpers": "^7.13.10",
-        "@babel/parser": "^7.13.10",
+        "@babel/parser": "^7.13.13",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/traverse": "^7.13.13",
+        "@babel/types": "^7.13.13",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -6710,12 +6719,12 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
-      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
+      "integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.8",
+        "@babel/compat-data": "^7.13.12",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
         "semver": "^6.3.0"
@@ -6857,9 +6866,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.12.tgz",
-      "integrity": "sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
       "dev": true
     },
     "@babel/template": {
@@ -6874,26 +6883,25 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
-      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+      "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.0",
+        "@babel/generator": "^7.13.9",
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/parser": "^7.13.13",
+        "@babel/types": "^7.13.13",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
-      "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
+      "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -7024,14 +7032,14 @@
       "dev": true
     },
     "@vue/compiler-core": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.7.tgz",
-      "integrity": "sha512-JFohgBXoyUc3mdeI2WxlhjQZ5fakfemJkZHX8Gu/nFbEg3+lKVUZmNKWmmnp9aOzJQZKoj77LjmFxiP+P+7lMQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.9.tgz",
+      "integrity": "sha512-bHAPwfVoLhGx8d6KV/OfGf/3gwpymVirgfmSyhgv5YuXDybLa6BwjSLvhNMAyDP+4q4pp0p6g248LuoOy5W6OA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.12.0",
         "@babel/types": "^7.12.0",
-        "@vue/shared": "3.0.7",
+        "@vue/shared": "3.0.9",
         "estree-walker": "^2.0.1",
         "source-map": "^0.6.1"
       },
@@ -7045,27 +7053,27 @@
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.7.tgz",
-      "integrity": "sha512-VnIH9EbWQm/Tkcp+8dCaNVsVvhm/vxCrIKWRkXY9215hTqOqQOvejT8IMjd2kc++nIsYMsdQk6H9qqBvoLe/Cw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.9.tgz",
+      "integrity": "sha512-tkq6umPSELaghvOExWfGNwrCRc7FTul3RLykKzBZWhb87sSESq0XxiKELfBOfEbzdhWg6BJ1WXKDeq+al/viEQ==",
       "dev": true,
       "requires": {
-        "@vue/compiler-core": "3.0.7",
-        "@vue/shared": "3.0.7"
+        "@vue/compiler-core": "3.0.9",
+        "@vue/shared": "3.0.9"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.0.7.tgz",
-      "integrity": "sha512-37/QILpGE+J3V+bP9Slg9e6xGqfk+MmS2Yj8ChR4fS0/qWUU/YoYHE0GPIzjmBdH0JVOOmJqunxowIXmqNiHng==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.0.9.tgz",
+      "integrity": "sha512-meneFRb9xIDgv/gYWCr9xKryvPi0tVffQzLjCkyN4RF1EndqLS71xugUX9wQsS4F1SAP+zlZbcgMFmTSC4OpHw==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.12.0",
-        "@babel/types": "^7.12.0",
-        "@vue/compiler-core": "3.0.7",
-        "@vue/compiler-dom": "3.0.7",
-        "@vue/compiler-ssr": "3.0.7",
-        "@vue/shared": "3.0.7",
+        "@babel/parser": "^7.13.9",
+        "@babel/types": "^7.13.0",
+        "@vue/compiler-core": "3.0.9",
+        "@vue/compiler-dom": "3.0.9",
+        "@vue/compiler-ssr": "3.0.9",
+        "@vue/shared": "3.0.9",
         "consolidate": "^0.16.0",
         "estree-walker": "^2.0.1",
         "hash-sum": "^2.0.0",
@@ -7102,52 +7110,52 @@
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.0.7.tgz",
-      "integrity": "sha512-nHRbHeSpfXwjypettjrA16TjgfDcPEwq3m/zHnGyLC1QqdLtklXmpSM43/CPwwTCRa/qdt0pldJf22MiCEuTSQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.0.9.tgz",
+      "integrity": "sha512-99h5k6Up+s8AzTNH1ljtXE/QlnG8yaGLePwQ4XQaWfk23ESUnmGZWEC+y+ZXznf8pIfJ0uPeD9EVgQzQAyZ2aA==",
       "dev": true,
       "requires": {
-        "@vue/compiler-dom": "3.0.7",
-        "@vue/shared": "3.0.7"
+        "@vue/compiler-dom": "3.0.9",
+        "@vue/shared": "3.0.9"
       }
     },
     "@vue/reactivity": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.7.tgz",
-      "integrity": "sha512-FotWcNNaKhqpFZrdgsUOZ1enlJ5lhTt01CNTtLSyK7jYFgZBTuw8vKsEutZKDYZ1XKotOfoeO8N3pZQqmM6Etw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.9.tgz",
+      "integrity": "sha512-W1AbGhzphVjY+TL32lQDwLDNvLzZKOcUgaIaLOoALWMtjzN4ExOUJzrR1FC3ynlpMHIEfcUo8GPgfnNmvMGdgQ==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@vue/shared": "3.0.7"
+        "@vue/shared": "3.0.9"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.7.tgz",
-      "integrity": "sha512-DBAZAwVvdmMXuyd6/9qqj/kYr/GaLTmn1L2/QLxLwP+UfhIboiTSBc/tUUb8MRk7Bb98GzNeAWkkT6AfooS3dQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.9.tgz",
+      "integrity": "sha512-j94xZ/wRZTVhqpoUgmxBTlojnPFu6TTXNw1Vw8oQkW1ZTGD0IwiJe3ycsKd1bpleXEMVt55GzGlCopI33/Gdmg==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@vue/reactivity": "3.0.7",
-        "@vue/shared": "3.0.7"
+        "@vue/reactivity": "3.0.9",
+        "@vue/shared": "3.0.9"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.7.tgz",
-      "integrity": "sha512-Oij4ruOtnpQpCj+/Q3JPzgpTJ1Q7+N67pA53A8KVITEtxfvKL46NN6dhAZ5NGqwX6RWZpYqWQNewITeF0pHr8g==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.9.tgz",
+      "integrity": "sha512-6NCjpwa5hNBFDdokquAgMl2tNEYyQD6kBy9Mh6M2776bxYLXZCqL4/e0UrpBuBiHTrkAlUGODD7PyYGaqH6fyA==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@vue/runtime-core": "3.0.7",
-        "@vue/shared": "3.0.7",
+        "@vue/runtime-core": "3.0.9",
+        "@vue/shared": "3.0.9",
         "csstype": "^2.6.8"
       }
     },
     "@vue/shared": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.7.tgz",
-      "integrity": "sha512-dn5FyfSc4ky424jH4FntiHno7Ss5yLkqKNmM/NXwANRnlkmqu74pnGetexDFVG5phMk9/FhwovUZCWGxsotVKg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.9.tgz",
+      "integrity": "sha512-lv20q1O5dybwro+V+vnxHCmSIxi9mvTORSgAbGrANGYK8zF4K1S9TOankIvdkcvfZ88IR95O2pTI2Pb3c3BaNg==",
       "dev": true
     },
     "accepts": {
@@ -7311,12 +7319,12 @@
       "dev": true
     },
     "async": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-      "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "^4.17.14"
       }
     },
     "asynckit": {
@@ -10960,6 +10968,15 @@
         "readdirp": "^2.1.0"
       },
       "dependencies": {
+        "async": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+          "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.14.0"
+          }
+        },
         "commander": {
           "version": "2.9.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
@@ -11682,15 +11699,15 @@
       "dev": true
     },
     "vue": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.7.tgz",
-      "integrity": "sha512-8h4TikD+JabbMK9aRlBO4laG0AtNHRPHynxYgWZ9sq1YUPfzynd9Jeeb27XNyZytC7aCQRX9xe1+TQJuc181Tw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.9.tgz",
+      "integrity": "sha512-MOvqDpvDslMWJo5kyGW1nTsTIPAuSzgVqmlzSQInIEqkHOu16pNbXuTjnG7jc/yIvQYFSQZqv6Pvad0iO5QkyQ==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@vue/compiler-dom": "3.0.7",
-        "@vue/runtime-dom": "3.0.7",
-        "@vue/shared": "3.0.7"
+        "@vue/compiler-dom": "3.0.9",
+        "@vue/runtime-dom": "3.0.9",
+        "@vue/shared": "3.0.9"
       }
     },
     "which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
         "uuid": "8.3.2"
       },
       "devDependencies": {
-        "async": "^2.1.5",
+        "async": "^3.2.0",
         "depcheck": "1.4.0",
-        "eslint": "7.22.0",
+        "eslint": "7.23.0",
         "eslint-plugin-mocha": "8.1.0",
         "express": "4.17.1",
         "flatted": "^3.1.1",
@@ -806,13 +806,10 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+      "dev": true
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1716,9 +1713,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.22.0.tgz",
-      "integrity": "sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.23.0.tgz",
+      "integrity": "sha512-kqvNVbdkjzpFy0XOszNwjkKzZ+6TcwCQ/h+ozlcIWwaimBBuhlQ4nN6kbiM2L+OjDcznkTJxzYfRFH92sx4a0Q==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
@@ -7319,13 +7316,10 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -8047,9 +8041,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.22.0.tgz",
-      "integrity": "sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.23.0.tgz",
+      "integrity": "sha512-kqvNVbdkjzpFy0XOszNwjkKzZ+6TcwCQ/h+ozlcIWwaimBBuhlQ4nN6kbiM2L+OjDcznkTJxzYfRFH92sx4a0Q==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
+    "async": "^2.1.5",
     "depcheck": "1.4.0",
     "eslint": "7.22.0",
     "eslint-plugin-mocha": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
-    "async": "^2.1.5",
+    "async": "^3.2.0",
     "depcheck": "1.4.0",
-    "eslint": "7.22.0",
+    "eslint": "7.23.0",
     "eslint-plugin-mocha": "8.1.0",
     "express": "4.17.1",
     "flatted": "^3.1.1",

--- a/test/cluster-test.js
+++ b/test/cluster-test.js
@@ -41,7 +41,7 @@ describe('LRU Cache for Clusters', () => {
             }
             return response.body === true
               ? done()
-              : done(new Error(response.body));
+              : done(new Error(response.body.error));
           });
       });
     });

--- a/test/cluster-test.js
+++ b/test/cluster-test.js
@@ -30,7 +30,8 @@ describe('LRU Cache for Clusters', () => {
 
   ['tests', 'clusterTests'].forEach((test) => {
     Object.keys(testUtils[test]).forEach((method) => {
-      it(`should ${testUtils[test][method]}`, (done) => {
+      it(`should ${testUtils[test][method]}`, function (done) {
+        this.timeout(config.timeout);
         // run the request
         request(`http://${config.server.host}:${config.server.port}`)
           .get(`/${method}`)

--- a/test/lib/cluster-master.js
+++ b/test/lib/cluster-master.js
@@ -72,11 +72,12 @@ module.exports = (done) => {
     });
   });
   return {
-    accessSharedFromMaster: (done2) => {
+    accessSharedFromMaster: async (done2) => {
       const cache = new LRUCache({
         namespace: 'test-cache',
       });
-      cache.keys().then(() => done2());
+      await cache.keys();
+      return done2();
     },
     getCacheMax: () => {
       const cache = new LRUCache({

--- a/test/lib/cluster-worker.js
+++ b/test/lib/cluster-worker.js
@@ -1,7 +1,7 @@
 const config = require('./test-config');
 const express = require('express');
 const http = require('http');
-const LRUCache = require('../../');
+const LRUCache = require('../../lru-cache-for-clusters-as-promised');
 const TestUtils = require('./test-utils');
 
 // this will be the SAME cache no matter which module calls it.
@@ -9,13 +9,6 @@ const initCache = new LRUCache();
 initCache.keys();
 
 require('../../lib/worker');
-
-// this will be the SAME cache no matter which module calls it.
-const defaultCache = new LRUCache({
-  max: 1,
-  maxAge: 100000,
-});
-defaultCache.keys();
 
 const cache = new LRUCache({
   namespace: 'test-cache',
@@ -32,7 +25,7 @@ const app = express();
     app.get(`/${method}`, (req, res) => {
       testUtils[method]((err) => {
         if (err) {
-          return res.send(err.message);
+          return res.send({ error: `${err.stack}` });
         }
         return res.send(true);
       });

--- a/test/lib/test-config.js
+++ b/test/lib/test-config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  timeout: 5000,
   args: {
     one: 'one',
     two: 'two',

--- a/test/lib/test-utils.js
+++ b/test/lib/test-utils.js
@@ -15,10 +15,16 @@ new LRUCacheForClustersAsPromised();
  * @return {void} Node style callback
  */
 function TestUtils(cache) {
-  const object = { foo: 'bar' };
+  const object = {
+    foo:
+      'bar barbarbar barbarbar barbarbar barbarbar barbarbar barbarbar barbarbar barbarbar barbar',
+  };
   const pairs = {
     foo: 'bar',
     bizz: 'buzz',
+    obj: {
+      hi: 'im an object',
+    },
   };
   const keys = Object.keys(pairs);
   return {

--- a/test/promise-test.js
+++ b/test/promise-test.js
@@ -1,6 +1,7 @@
+const async = require('async');
 const LRUCacheForClustersAsPromised = require('../lru-cache-for-clusters-as-promised');
 const TestUtils = require('./lib/test-utils');
-const async = require('async');
+const config = require('./lib/test-config');
 
 describe('LRU Cache as Promised', async () => {
   const cache = new LRUCacheForClustersAsPromised({
@@ -21,7 +22,8 @@ describe('LRU Cache as Promised', async () => {
 
   await async.eachOf(Object.keys(testUtils.tests), async (method) => {
     return new Promise((resolve, reject) => {
-      it(`should ${testUtils.tests[method]}`, () => {
+      it(`should ${testUtils.tests[method]}`, function () {
+        this.timeout(config.timeout);
         // run the request
         testUtils[method]((err) => {
           if (err) {

--- a/test/promise-test.js
+++ b/test/promise-test.js
@@ -1,7 +1,8 @@
 const LRUCache = require('../');
 const TestUtils = require('./lib/test-utils');
+const async = require('async');
 
-describe('LRU Cache as Promised', () => {
+describe('LRU Cache as Promised', async () => {
   const cache = new LRUCache({
     namespace: 'lru-cache-as-promised',
     max: 3,
@@ -10,19 +11,23 @@ describe('LRU Cache as Promised', () => {
 
   const testUtils = new TestUtils(cache);
 
+  before(function () {
+    this.timeout(5000);
+  });
+
   afterEach((done) => {
     testUtils.reset(done);
   });
 
-  ['tests'].forEach((test) => {
-    Object.keys(testUtils[test]).forEach((method) => {
-      it(`should ${testUtils[test][method]}`, (done) => {
+  await async.eachOf(Object.keys(testUtils.tests), async (method) => {
+    return new Promise((resolve, reject) => {
+      it(`should ${testUtils.tests[method]}`, () => {
         // run the request
         testUtils[method]((err) => {
           if (err) {
-            return done(err);
+            return reject(err);
           }
-          return done();
+          return resolve();
         });
       });
     });

--- a/test/promise-test.js
+++ b/test/promise-test.js
@@ -1,9 +1,9 @@
-const LRUCache = require('../');
+const LRUCacheForClustersAsPromised = require('../lru-cache-for-clusters-as-promised');
 const TestUtils = require('./lib/test-utils');
 const async = require('async');
 
 describe('LRU Cache as Promised', async () => {
-  const cache = new LRUCache({
+  const cache = new LRUCacheForClustersAsPromised({
     namespace: 'lru-cache-as-promised',
     max: 3,
     stale: false,


### PR DESCRIPTION
add execute() method to allow arbitrary commands to be executed
add getAllCaches() to return the underlying LRUCache objects by namespace
add getCache() to return the underlying LRUCache for a namespace
add getInstance() to allow for asynchronous class loading
bugfix: update options when options change on promisified request for master
bugfix: fix method name to `allowStale()` for the `stale` option, deprecate `stale()`
update: removed 'func' in response message, not needed
update types

add test coverage